### PR TITLE
feat!: add support for different engines

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,10 @@ types can be found
 ## Resources
 
 - [JSON and XML conversion](https://wiki.open311.org/JSON_and_XML_Conversion/)
+
+
+## Acknowledgements
+
+- [Tesla JSON Middleware](https://github.com/elixir-tesla/tesla/blob/52bf0ff600cd452471d3fc518f53436f2e48e60f/lib/tesla/middleware/json.ex)
+- [Saxy](https://github.com/qcam/saxy)
+- [XmlJson](https://github.com/bennyhat/xml_json)

--- a/lib/adapters/saxy.ex
+++ b/lib/adapters/saxy.ex
@@ -1,0 +1,14 @@
+defmodule Tesla.Middleware.XML.Adapters.Saxy do
+  @default_handler Saxy.SimpleForm.Handler
+  @default_handler_opts []
+
+  def encode(data, _opts) do
+    Saxy.encode!(data)
+  end
+
+  def decode(data, opts) do
+    handler = Keyword.get(opts, :convention, @default_handler)
+    opts = Keyword.get(opts, :convention, @default_handler_opts)
+    Saxy.parse_string(data, handler, opts)
+  end
+end

--- a/lib/adapters/xml_json.ex
+++ b/lib/adapters/xml_json.ex
@@ -1,0 +1,21 @@
+defmodule Tesla.Middleware.XML.Adapters.XmlJson do
+  @default_convention Parker
+  # [preserve_root: "root"]
+  @default_encode_opts []
+  # [preserve_root: true]
+  @default_decode_opts []
+
+  def encode(data, opts) do
+    convention = Keyword.get(opts, :convention, @default_convention)
+    opts = Keyword.get(opts, :convention, @default_encode_opts)
+    module = Module.concat(XmlJson, convention)
+    apply(module, :serialize, [data, opts])
+  end
+
+  def decode(data, opts) do
+    convention = Keyword.get(opts, :convention, @default_convention)
+    opts = Keyword.get(opts, :convention, @default_decode_opts)
+    module = Module.concat(XmlJson, convention)
+    apply(module, :deserialize, [data, opts])
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -46,7 +46,10 @@ defmodule Tesla.Middleware.XML.MixProject do
   defp deps do
     [
       {:tesla, "~> 1.9"},
-      {:xml_json, "~> 0.4.2"},
+
+      # xml parsers
+      {:saxy, "~> 1.5", optional: true},
+      {:xml_json, "~> 0.4.2", optional: true},
 
       # development
       {:ex_doc, "~> 0.31", only: :dev, runtime: false}

--- a/test/middleware/xml_test.exs
+++ b/test/middleware/xml_test.exs
@@ -217,4 +217,27 @@ defmodule Tesla.Middleware.XmlTest do
       assert env.body == "ok"
     end
   end
+
+  describe "Engine: Saxy" do
+    defmodule SaxyClient do
+      use Tesla
+
+      plug Tesla.Middleware.XML, engine: Saxy
+
+      adapter fn env ->
+        {:ok,
+         %{
+           env
+           | status: 200,
+             headers: [{"content-type", "application/xml"}],
+             body: ~s|<value>123</value>|
+         }}
+      end
+    end
+
+    test "decode with custom engine options" do
+      assert {:ok, env} = SaxyClient.get("/decode")
+      assert env.body == {"value", [], ["123"]}
+    end
+  end
 end

--- a/test/middleware/xml_test.exs
+++ b/test/middleware/xml_test.exs
@@ -81,7 +81,7 @@ defmodule Tesla.Middleware.XmlTest do
     end
 
     test "return error on encoding error" do
-      assert {:error, {Tesla.Middleware.XML, :serialize, _}} =
+      assert {:error, {Tesla.Middleware.XML, :encode, _}} =
                Client.post("/encode", %{pid: self()})
     end
 
@@ -94,11 +94,11 @@ defmodule Tesla.Middleware.XmlTest do
     end
 
     test "return error when decoding invalid xml format" do
-      assert {:error, {Tesla.Middleware.XML, :deserialize, _}} = Client.get("/invalid-xml-format")
+      assert {:error, {Tesla.Middleware.XML, :decode, _}} = Client.get("/invalid-xml-format")
     end
 
     test "raise error when decoding non-utf8 xml" do
-      assert {:error, {Tesla.Middleware.XML, :deserialize, _}} =
+      assert {:error, {Tesla.Middleware.XML, :decode, _}} =
                Client.get("/invalid-xml-encoding")
     end
   end


### PR DESCRIPTION
## Description

Just like `Tesla.Middleware.JSON`, let users specify what library they want to use for encoding/decoding XML requests and responses.

For example, this will allow users to specify other less lossy ways of decoding/encoding XML documents (eg. Saxy's simple form).